### PR TITLE
Add favicons to tab lists

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -45,6 +45,8 @@ main#dashboard {
   padding: 5px;
   cursor: grab;
   border-bottom: 1px solid #eee;
+  display: flex;
+  align-items: center;
 }
 
 #categories {
@@ -87,12 +89,20 @@ flex-grow: 1;
 overflow-y: auto;
 }
 .tab-list li {
-margin-bottom: 5px;
+  margin-bottom: 5px;
+  display: flex;
+  align-items: center;
 }
 .tab-list li a {
-text-decoration: none;
-color: #333;
-font-size: 14px;
+  text-decoration: none;
+  color: #333;
+  font-size: 14px;
+}
+
+.favicon {
+  width: 16px;
+  height: 16px;
+  margin-right: 5px;
 }
 .open-btn {
   margin-top: 10px;

--- a/dashboard.html
+++ b/dashboard.html
@@ -19,7 +19,6 @@
             <ul id="openTabs"></ul>
         </section>
         <section id="categories"></section>
-<main id="categories">
     </main>
     <script src="dashboard.js"></script>
 </body>

--- a/dashboard.js
+++ b/dashboard.js
@@ -12,7 +12,12 @@ function loadOpenTabs() {
     openTabsList.innerHTML = '';
     tabs.forEach(tab => {
       const li = document.createElement('li');
-      li.textContent = tab.title || tab.url;
+      const img = document.createElement('img');
+      img.src = tab.favIconUrl || `chrome://favicon/${tab.url}`;
+      img.className = 'favicon';
+      const span = document.createElement('span');
+      span.textContent = tab.title || tab.url;
+      li.append(img, span);
       li.draggable = true;
       li.addEventListener('dragstart', e => {
         e.dataTransfer.setData('text/plain', JSON.stringify({ url: tab.url, title: tab.title }));
@@ -68,11 +73,14 @@ card.className = 'category-card';
     });
     cats[cat].forEach(tab => {
       const li = document.createElement('li');
+      const img = document.createElement('img');
+      img.src = `chrome://favicon/${tab.url}`;
+      img.className = 'favicon';
       const a = document.createElement('a');
       a.href = tab.url;
       a.textContent = tab.title;
       a.target = '_blank';
-      li.appendChild(a);
+      li.append(img, a);
       ul.appendChild(li);
     });
     card.appendChild(ul);


### PR DESCRIPTION
## Summary
- fix HTML structure in dashboard
- show site favicons for open and saved tabs
- style tab lists for favicon placement

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846e624e4e08323b37cf03cb0a319b3