### PR TITLE
Add dark mode, tab renaming, and theme color

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -2,6 +2,17 @@
   --primary: #6200ee;
   --bg: #f0f2f5;
   --card-bg: #fff;
+  --text: #000;
+  --border: #ddd;
+  --border-light: #eee;
+}
+
+body.dark {
+  --bg: #121212;
+  --card-bg: #1e1e1e;
+  --text: #eee;
+  --border: #444;
+  --border-light: #333;
 }
 
 body {
@@ -9,6 +20,7 @@ body {
   margin: 0;
   padding: 0;
   background: var(--bg);
+  color: var(--text);
 }
 header {
   display: flex;
@@ -19,13 +31,32 @@ header {
   color: #fff;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
+
+#controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+#dark-label {
+  color: #fff;
+  font-size: 14px;
+}
+
+#themeColor {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  background: none;
+}
 header h1 {
 font-size: 24px;
 }
 #add-control input {
   padding: 5px;
   border-radius: 4px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border);
 }
 #add-control button {
   padding: 5px 10px;
@@ -43,10 +74,9 @@ main#dashboard {
 
 #open-tabs {
   width: 250px;
-  border-right: 1px solid #ddd;
+  border-right: 1px solid var(--border);
   padding: 10px;
   overflow-y: auto;
-  background: #fafafa;
   background: var(--card-bg);
 }
 
@@ -59,9 +89,10 @@ main#dashboard {
 #openTabs li {
   padding: 5px;
   cursor: grab;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--border-light);
   display: flex;
   align-items: center;
+  color: var(--text);
 }
 
 #categories {
@@ -108,10 +139,18 @@ overflow-y: auto;
   display: flex;
   align-items: center;
 }
+.rename-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  margin-left: 5px;
+  color: var(--text);
+}
 .tab-list li a {
   text-decoration: none;
-  color: #333;
+  color: var(--text);
   font-size: 14px;
+  flex-grow: 1;
 }
 
 .favicon {
@@ -139,7 +178,7 @@ overflow-y: auto;
   flex: 1;
   padding: 5px;
   border-radius: 4px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border);
 }
 
 .manual-add button {

--- a/dashboard.html
+++ b/dashboard.html
@@ -8,9 +8,13 @@
 <body>
     <header>
         <h1>Tab Manager</h1>
-        <div id="add-control">
-            <input type="text" id="newCategory" placeholder="New category" />
-            <button id="addCategory">Add</button>
+        <div id="controls">
+            <label id="dark-label"><input type="checkbox" id="darkToggle"> Dark Mode</label>
+            <input type="color" id="themeColor" title="Theme Color">
+            <div id="add-control">
+                <input type="text" id="newCategory" placeholder="New category" />
+                <button id="addCategory">Add</button>
+            </div>
         </div>
     </header>
     <main id="dashboard">


### PR DESCRIPTION
## Summary
- add dark mode toggle and theme color picker
- allow renaming tabs inside categories
- style dashboard for light/dark themes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6846e8f3f4488323bd8141137cfd3416