### PR TITLE
Fix tab rename and improve styling

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -38,9 +38,63 @@ header {
   gap: 10px;
 }
 
+
 #dark-label {
+  display: flex;
+  align-items: center;
   color: #fff;
   font-size: 14px;
+  gap: 6px;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: #ccc;
+  transition: 0.2s;
+  border-radius: 20px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 16px;
+  width: 16px;
+  left: 2px;
+  bottom: 2px;
+  background: #fff;
+  transition: 0.2s;
+  border-radius: 50%;
+}
+
+.label-text {
+  margin-left: 6px;
+  color: #fff;
+}
+
+input:checked + .slider {
+  background: var(--primary);
+}
+
+input:checked + .slider:before {
+  transform: translateX(20px);
 }
 
 #themeColor {
@@ -136,8 +190,14 @@ overflow-y: auto;
 }
 .tab-list li {
   margin-bottom: 5px;
+  padding: 4px 6px;
   display: flex;
   align-items: center;
+  background: var(--bg);
+  border-radius: 4px;
+}
+.tab-list li + li {
+  margin-top: 5px;
 }
 .rename-btn {
   background: none;

--- a/dashboard.html
+++ b/dashboard.html
@@ -9,7 +9,11 @@
     <header>
         <h1>Tab Manager</h1>
         <div id="controls">
-            <label id="dark-label"><input type="checkbox" id="darkToggle"> Dark Mode</label>
+            <label id="dark-label" class="switch">
+                <input type="checkbox" id="darkToggle">
+                <span class="slider"></span>
+                <span class="label-text">Dark Mode</span>
+            </label>
             <input type="color" id="themeColor" title="Theme Color">
             <div id="add-control">
                 <input type="text" id="newCategory" placeholder="New category" />

--- a/dashboard.js
+++ b/dashboard.js
@@ -65,9 +65,10 @@ function addTabToCategory(cat, tab) {
 }
 
 function renameTab(cat, index, title) {
+  const idx = parseInt(index, 10);
   chrome.storage.sync.get({ categories: {} }, data => {
-    if (!data.categories[cat] || !data.categories[cat][index]) return;
-    data.categories[cat][index].title = title;
+    if (!data.categories[cat] || !data.categories[cat][idx]) return;
+    data.categories[cat][idx].title = title;
     chrome.storage.sync.set({ categories: data.categories }, loadCategories);
   });
 }
@@ -129,7 +130,8 @@ card.addEventListener('drop', e => {
       rename.textContent = '✎';
       rename.title = 'Rename tab';
       rename.className = 'rename-btn';
-      rename.onclick = () => {
+      rename.onclick = e => {
+        e.stopPropagation();
         const nt = prompt('New title', tab.title);
         if (nt) renameTab(cat, idx, nt);
       };


### PR DESCRIPTION
## Summary
- add toggle switch for dark mode
- let rename button work for the first tab
- style each tab with padding and background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846ea58ec38832389da548cf1dba9d2