### PR TITLE
Improve dashboard UI elements

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -39,7 +39,7 @@ header {
 }
 
 
-#dark-label {
+#dark-control {
   display: flex;
   align-items: center;
   color: #fff;
@@ -104,6 +104,13 @@ input:checked + .slider:before {
   border: none;
   background: none;
 }
+
+#theme-control {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #fff;
+}
 header h1 {
 font-size: 24px;
 }
@@ -147,6 +154,13 @@ main#dashboard {
   display: flex;
   align-items: center;
   color: var(--text);
+}
+
+#openTabs li span {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 #categories {
@@ -211,6 +225,9 @@ overflow-y: auto;
   color: var(--text);
   font-size: 14px;
   flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .favicon {

--- a/dashboard.html
+++ b/dashboard.html
@@ -9,12 +9,17 @@
     <header>
         <h1>Tab Manager</h1>
         <div id="controls">
-            <label id="dark-label" class="switch">
-                <input type="checkbox" id="darkToggle">
-                <span class="slider"></span>
+            <div id="dark-control">
+                <label class="switch">
+                    <input type="checkbox" id="darkToggle">
+                    <span class="slider"></span>
+                </label>
                 <span class="label-text">Dark Mode</span>
-            </label>
-            <input type="color" id="themeColor" title="Theme Color">
+            </div>
+            <div id="theme-control">
+                <label for="themeColor">Theme</label>
+                <input type="color" id="themeColor" title="Theme Color">
+            </div>
             <div id="add-control">
                 <input type="text" id="newCategory" placeholder="New category" />
                 <button id="addCategory">Add</button>


### PR DESCRIPTION
## Summary
- adjust dark mode toggle layout
- add theme color label and container
- prevent long tab titles from breaking layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846ebad73cc8323af40e68dae4b00ab