### PR TITLE
Fix color defaults and UI issues

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -1,5 +1,5 @@
 :root {
-  --primary: #6200ee;
+  --primary: #4A399D;
   --bg: #f0f2f5;
   --card-bg: #fff;
   --text: #000;
@@ -165,11 +165,12 @@ main#dashboard {
 
 #categories {
   flex: 1;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 15px;
   padding: 20px;
   overflow-y: auto;
+  align-content: flex-start;
 }
 .category-card {
   background: var(--card-bg);
@@ -181,6 +182,7 @@ main#dashboard {
   resize: horizontal;
   overflow: auto;
   min-width: 200px;
+  flex: 0 0 auto;
 }
 .category-header {
 display: flex;

--- a/dashboard.js
+++ b/dashboard.js
@@ -8,7 +8,7 @@ const openTabsList = document.getElementById('openTabs');
 const darkToggle = document.getElementById('darkToggle');
 const themeColorInput = document.getElementById('themeColor');
 
-chrome.storage.sync.get({ darkMode: false, themeColor: '#6200ee' }, data => {
+chrome.storage.sync.get({ darkMode: false, themeColor: '#4A399D' }, data => {
   if (data.darkMode) document.body.classList.add('dark');
   darkToggle.checked = data.darkMode;
   document.documentElement.style.setProperty('--primary', data.themeColor);
@@ -27,12 +27,12 @@ chrome.storage.sync.set({ themeColor: themeColorInput.value });
 
 function getCategoryData(cats, cat) {
   if (!cats[cat]) {
-    cats[cat] = { tabs: [], color: '#fff', icon: 'folder' };
+    cats[cat] = { tabs: [], color: '', icon: 'folder' };
   } else if (Array.isArray(cats[cat])) {
-    cats[cat] = { tabs: cats[cat], color: '#fff', icon: 'folder' };
+    cats[cat] = { tabs: cats[cat], color: '', icon: 'folder' };
   } else {
     cats[cat].tabs = cats[cat].tabs || [];
-    cats[cat].color = cats[cat].color || '#fff';
+    cats[cat].color = cats[cat].color || '';
     cats[cat].icon = cats[cat].icon || 'folder';
   }
   return cats[cat];
@@ -98,7 +98,7 @@ function loadCategories() {
 const card = document.createElement('div');
 card.className = 'category-card';
 const catData = getCategoryData(cats, cat);
-card.style.background = catData.color;
+card.style.background = !catData.color || catData.color === '#fff' ? 'var(--card-bg)' : catData.color;
 card.draggable = true;
 card.addEventListener('dragstart', e => {
   e.dataTransfer.setData('text/plain', cat);
@@ -117,7 +117,7 @@ card.addEventListener('drop', e => {
     icon.className = 'material-icons category-icon';
     icon.textContent = catData.icon;
     const title = document.createElement('h2');
-    title.textContent = `${cat} (${catData.tabs.length})`;
+    title.textContent = cat;
     const editBtn = document.createElement('button');
     editBtn.textContent = '✎';
     editBtn.title = 'Edit category';


### PR DESCRIPTION
## Summary
- switch default theme color to `#4A399D`
- refine layout for resizable category cards
- remove tab count from category headings
- improve dark mode handling for cards

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846ee932e4c83239570f6d0425c3f47