### PR TITLE
Add emoji picker for category icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Tab Manager Dashboard is a minimal Chrome extension that lets you organize your 
 - **Quick open**: Open all tabs in a category with a single click.
 - **Context menu**: Right‑click anywhere and choose "Save all open tabs to category" to archive your session.
 - **Sync storage**: Categories are stored using Chrome's `storage.sync` so they can be shared between browsers signed into the same account.
+- **Emoji icons**: Pick an emoji to represent each category using a built-in selector.
 
 ## Installation
 

--- a/dashboard.css
+++ b/dashboard.css
@@ -227,6 +227,36 @@ overflow-y: auto;
   margin-left: 5px;
   color: var(--text);
 }
+
+.emoji-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.emoji-picker {
+  background: var(--card-bg);
+  padding: 10px;
+  border-radius: 8px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(32px, 1fr));
+  gap: 6px;
+  max-width: 300px;
+}
+
+.emoji-btn {
+  font-size: 24px;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
 .tab-list li a {
   text-decoration: none;
   color: var(--text);

--- a/dashboard.js
+++ b/dashboard.js
@@ -261,14 +261,43 @@ function reorderCategories(fromCat, toCat) {
   });
 }
 
+function showEmojiPicker(current) {
+  return new Promise(resolve => {
+    const overlay = document.createElement('div');
+    overlay.className = 'emoji-overlay';
+    const picker = document.createElement('div');
+    picker.className = 'emoji-picker';
+    const emojis =
+      '😀 😃 😄 😁 😆 😅 😂 🙂 🙃 😉 😊 😇 😍 🤩 😋 😜 🤪 🤔 😎 😕 😢 😭 😡 👍 👎 ⭐ ⚡ 🎉'.split(' ');
+    emojis.forEach(e => {
+      const btn = document.createElement('button');
+      btn.className = 'emoji-btn';
+      btn.textContent = e;
+      btn.onclick = () => {
+        document.body.removeChild(overlay);
+        resolve(e);
+      };
+      picker.appendChild(btn);
+    });
+    overlay.addEventListener('click', evt => {
+      if (evt.target === overlay) {
+        document.body.removeChild(overlay);
+        resolve(current);
+      }
+    });
+    overlay.appendChild(picker);
+    document.body.appendChild(overlay);
+  });
+}
+
 function editCategory(oldName) {
-  chrome.storage.sync.get({ categories: {}, categoryOrder: [] }, data => {
+  chrome.storage.sync.get({ categories: {}, categoryOrder: [] }, async data => {
     const cats = data.categories;
     const order = data.categoryOrder;
     const catData = getCategoryData(cats, oldName);
     const newName = prompt('Category name', oldName);
     if (!newName) return;
-    const newIcon = prompt('Icon name (material icon)', catData.icon) || catData.icon;
+    const newIcon = await showEmojiPicker(catData.icon);
     const newColor = prompt('Background color', catData.color) || catData.color;
     catData.icon = newIcon;
     catData.color = newColor;


### PR DESCRIPTION
## Summary
- enable picking category icons using an emoji selector
- style the emoji selector overlay
- document emoji icons in README

## Testing
- `npm test` *(fails: ENOENT: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846ef1964508323a848a51f2a3ad588