### PR TITLE
Fix drag/drop and emoji picker

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -149,8 +149,22 @@ card.addEventListener('drop', e => {
     ul.addEventListener('dragover', e => e.preventDefault());
     ul.addEventListener('drop', e => {
       e.preventDefault();
-      const data = e.dataTransfer.getData('text/plain');
-      if (data) addTabToCategory(cat, JSON.parse(data));
+      const plain = e.dataTransfer.getData('text/plain');
+      const uri = e.dataTransfer.getData('text/uri-list');
+      let tabData = null;
+      if (plain) {
+        try {
+          const obj = JSON.parse(plain);
+          if (obj && obj.url) tabData = obj;
+        } catch (err) {
+          // ignore JSON parse errors and treat as plain URL below
+        }
+      }
+      const url = tabData ? null : (uri || plain);
+      if (!tabData && url) {
+        tabData = { url, title: url, favIconUrl: '' };
+      }
+      if (tabData) addTabToCategory(cat, tabData);
     });
     catData.tabs.forEach((tab, idx) => {
       const li = document.createElement('li');

--- a/manifest.json
+++ b/manifest.json
@@ -9,5 +9,8 @@
 },
 "icons": {
 "16": "icon.png"
+},
+"content_security_policy": {
+  "extension_pages": "script-src 'self' https://cdn.jsdelivr.net; object-src 'self'"
 }
 }


### PR DESCRIPTION
## Summary
- handle plain URLs when dragging links to a category
- allow loading the emoji picker script from jsDelivr

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846fba7a7fc8323841c7b8f2d603b66