### PR TITLE
Fix drag-and-drop on empty categories

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -227,6 +227,7 @@ margin: 0;
 padding: 0;
 flex-grow: 1;
 overflow-y: auto;
+min-height: 40px; /* ensure droppable area when empty */
 }
 .tab-list li {
   margin-bottom: 5px;


### PR DESCRIPTION
## Summary
- ensure `.tab-list` has a minimum height so it can receive drops even when empty

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846fe8e884c8323b3bfb65200198c9c