### PR TITLE
Add service worker for context menu

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,49 @@
+function getCategoryData(cats, cat) {
+  if (!cats[cat]) {
+    cats[cat] = { tabs: [], color: '', icon: 'folder' };
+  } else if (Array.isArray(cats[cat])) {
+    cats[cat] = { tabs: cats[cat], color: '', icon: 'folder' };
+  } else {
+    cats[cat].tabs = cats[cat].tabs || [];
+    cats[cat].color = cats[cat].color || '';
+    cats[cat].icon = cats[cat].icon || 'folder';
+  }
+  return cats[cat];
+}
+
+function saveTabs(cat) {
+  chrome.tabs.query({}, tabs => {
+    chrome.storage.sync.get({ categories: {}, categoryOrder: [] }, data => {
+      const cats = data.categories;
+      const order = data.categoryOrder;
+      const catData = getCategoryData(cats, cat);
+      catData.tabs = tabs.map(t => ({ url: t.url, title: t.title, favIconUrl: t.favIconUrl || '' }));
+      if (!order.includes(cat)) order.push(cat);
+      chrome.storage.sync.set({ categories: cats, categoryOrder: order });
+    });
+  });
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({
+    id: 'save-tabs',
+    title: 'Save all open tabs to category',
+    contexts: ['all']
+  });
+});
+
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId === 'save-tabs') {
+    chrome.scripting.executeScript(
+      {
+        target: { tabId: tab.id },
+        func: () => prompt('Enter category name:')
+      },
+      results => {
+        if (chrome.runtime.lastError) return;
+        const cat = results && results[0] ? results[0].result : null;
+        if (cat) saveTabs(cat);
+      }
+    );
+  }
+});

--- a/dashboard.js
+++ b/dashboard.js
@@ -346,20 +346,7 @@ function setCategoryColor(cat, color) {
   });
 }
 
-// Context menu for saving tabs
-chrome.runtime.onInstalled.addListener(() => {
-chrome.contextMenus.create({
-id: 'save-tabs',
-title: 'Save all open tabs to category',
-contexts: ['all']
-});
-});
-chrome.contextMenus.onClicked.addListener(info => {
-if (info.menuItemId === 'save-tabs') {
-const cat = prompt('Enter category name:');
-if (cat) saveTabs(cat);
-}
-});
+// Context menu setup moved to background.js
 
 loadOpenTabs();
 loadCategories();

--- a/manifest.json
+++ b/manifest.json
@@ -3,14 +3,17 @@
 "name": "Tab Manager Dashboard",
 "description": "Group tabs under categories and open them quickly via a New Tab dashboard",
 "version": "1.0",
-  "permissions": ["tabs", "storage", "contextMenus"],
+  "permissions": ["tabs", "storage", "contextMenus", "scripting"],
 "chrome_url_overrides": {
 "newtab": "dashboard.html"
 },
 "icons": {
 "16": "icon.png"
 },
-"content_security_policy": {
-  "extension_pages": "script-src 'self' https://cdn.jsdelivr.net; object-src 'self'"
-}
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_security_policy": {
+    "extension_pages": "script-src 'self' https://cdn.jsdelivr.net; object-src 'self'"
+  }
 }


### PR DESCRIPTION
## Summary
- move context menu registration into new `background.js` service worker
- reference `background.js` from `manifest.json`
- remove old context menu setup from `dashboard.js`

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6848020997fc8323ad3df50e15a3df68