### PR TITLE
Refactor duplicate tab helpers

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,28 +1,4 @@
-function getCategoryData(cats, cat) {
-  if (!cats[cat]) {
-    cats[cat] = { tabs: [], color: '', icon: 'folder' };
-  } else if (Array.isArray(cats[cat])) {
-    cats[cat] = { tabs: cats[cat], color: '', icon: 'folder' };
-  } else {
-    cats[cat].tabs = cats[cat].tabs || [];
-    cats[cat].color = cats[cat].color || '';
-    cats[cat].icon = cats[cat].icon || 'folder';
-  }
-  return cats[cat];
-}
-
-function saveTabs(cat) {
-  chrome.tabs.query({}, tabs => {
-    chrome.storage.sync.get({ categories: {}, categoryOrder: [] }, data => {
-      const cats = data.categories;
-      const order = data.categoryOrder;
-      const catData = getCategoryData(cats, cat);
-      catData.tabs = tabs.map(t => ({ url: t.url, title: t.title, favIconUrl: t.favIconUrl || '' }));
-      if (!order.includes(cat)) order.push(cat);
-      chrome.storage.sync.set({ categories: cats, categoryOrder: order });
-    });
-  });
-}
+import { getCategoryData, saveTabs } from './utils.js';
 
 chrome.runtime.onInstalled.addListener(() => {
   chrome.contextMenus.create({

--- a/dashboard.html
+++ b/dashboard.html
@@ -35,6 +35,6 @@
         <section id="categories"></section>
     </main>
     <script type="module" src="https://cdn.jsdelivr.net/npm/emoji-picker-element@^1"></script>
-    <script src="dashboard.js"></script>
-</body>
+    <script type="module" src="dashboard.js"></script>
+  </body>
 </html>

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,4 +1,5 @@
 // Manage categories and tabs on dashboard view
+import { getCategoryData } from './utils.js';
 
 document.addEventListener('DOMContentLoaded', () => {
 const newCatInput = document.getElementById('newCategory');
@@ -25,18 +26,6 @@ themeColorInput.addEventListener('input', () => {
 chrome.storage.sync.set({ themeColor: themeColorInput.value });
 });
 
-function getCategoryData(cats, cat) {
-  if (!cats[cat]) {
-    cats[cat] = { tabs: [], color: '', icon: 'folder' };
-  } else if (Array.isArray(cats[cat])) {
-    cats[cat] = { tabs: cats[cat], color: '', icon: 'folder' };
-  } else {
-    cats[cat].tabs = cats[cat].tabs || [];
-    cats[cat].color = cats[cat].color || '';
-    cats[cat].icon = cats[cat].icon || 'folder';
-  }
-  return cats[cat];
-}
 
 // Load currently open tabs
 function loadOpenTabs() {
@@ -261,19 +250,6 @@ chrome.storage.sync.set({ categories: cats, categoryOrder: order }, loadCategori
 });
 }
 
-// Save current tabs
-function saveTabs(cat) {
-chrome.tabs.query({}, tabs => {
-chrome.storage.sync.get({ categories: {}, categoryOrder: [] }, data => {
-const cats = data.categories;
-const order = data.categoryOrder;
-const catData = getCategoryData(cats, cat);
-catData.tabs = tabs.map(t => ({ url: t.url, title: t.title, favIconUrl: t.favIconUrl || '' }));
-if (!order.includes(cat)) order.push(cat);
-chrome.storage.sync.set({ categories: cats, categoryOrder: order }, loadCategories);
-});
-});
-}
 
 // Open all tabs in category
 function openCategory(cat) {

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,8 @@
 "16": "icon.png"
 },
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "content_security_policy": {
     "extension_pages": "script-src 'self' https://cdn.jsdelivr.net; object-src 'self'"

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,32 @@
+// Shared utility functions for tab management
+
+export function getCategoryData(cats, cat) {
+  if (!cats[cat]) {
+    cats[cat] = { tabs: [], color: '', icon: 'folder' };
+  } else if (Array.isArray(cats[cat])) {
+    cats[cat] = { tabs: cats[cat], color: '', icon: 'folder' };
+  } else {
+    cats[cat].tabs = cats[cat].tabs || [];
+    cats[cat].color = cats[cat].color || '';
+    cats[cat].icon = cats[cat].icon || 'folder';
+  }
+  return cats[cat];
+}
+
+export function saveTabs(cat, callback) {
+  chrome.tabs.query({}, tabs => {
+    chrome.storage.sync.get({ categories: {}, categoryOrder: [] }, data => {
+      const cats = data.categories;
+      const order = data.categoryOrder;
+      const catData = getCategoryData(cats, cat);
+      catData.tabs = tabs.map(t => ({
+        url: t.url,
+        title: t.title,
+        favIconUrl: t.favIconUrl || ''
+      }));
+      if (!order.includes(cat)) order.push(cat);
+      chrome.storage.sync.set({ categories: cats, categoryOrder: order }, callback);
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- extract `getCategoryData` and `saveTabs` into `utils.js`
- import `utils.js` in the background worker and dashboard
- load dashboard script as a module
- declare background worker as an ES module

## Testing
- `node -c utils.js`
- `node -c background.js`
- `node -c dashboard.js`


------
https://chatgpt.com/codex/tasks/task_e_68480b39800c8323ba29f3cc821e8d3f