### PR TITLE
Fix CSP error by removing CDN script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tab Manager Dashboard is a minimal Chrome extension that lets you organize your 
 - **Quick open**: Open all tabs in a category with a single click.
 - **Context menu**: Right‑click anywhere and choose "Save all open tabs to category" to archive your session.
 - **Sync storage**: Categories are stored using Chrome's `storage.sync` so they can be shared between browsers signed into the same account.
-- **Emoji icons**: Uses the `emoji-picker-element` library for a macOS-style emoji chooser.
+- **Emoji icons**: Pick category icons using a simple built-in prompt.
 
 ## Preview
 

--- a/dashboard.css
+++ b/dashboard.css
@@ -306,3 +306,21 @@ main#dashboard {
   color: #fff;
   cursor: pointer;
 }
+
+/* Styling for the simple emoji picker overlay */
+.emoji-overlay input {
+  font-size: 24px;
+  padding: 10px;
+  width: 4em;
+  text-align: center;
+}
+
+.emoji-overlay button {
+  margin-left: 10px;
+  padding: 10px 15px;
+  border: none;
+  border-radius: 4px;
+  background: var(--primary);
+  color: #fff;
+  cursor: pointer;
+}

--- a/dashboard.html
+++ b/dashboard.html
@@ -37,12 +37,6 @@
       </section>
       <section id="categories"></section>
     </main>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/emoji-picker-element@^1"></script>
     <script type="module" src="dashboard.js"></script>
-    <script
-      type="module"
-      src="https://cdn.jsdelivr.net/npm/emoji-picker-element@^1"
-    ></script>
-    <script src="dashboard.js"></script>
   </body>
 </html>

--- a/dashboard.js
+++ b/dashboard.js
@@ -329,18 +329,22 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   async function showEmojiPicker(current) {
-    if (!customElements.get('emoji-picker')) {
-      await import('https://cdn.jsdelivr.net/npm/emoji-picker-element@^1');
-    }
     return new Promise((resolve) => {
       const overlay = document.createElement('div');
       overlay.className = 'emoji-overlay';
-      const picker = document.createElement('emoji-picker');
 
-      picker.addEventListener('emoji-click', (e) => {
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.value = current || '';
+      input.placeholder = '🙂';
+
+      const button = document.createElement('button');
+      button.textContent = 'OK';
+
+      button.onclick = () => {
         overlay.remove();
-        resolve(e.detail.unicode);
-      });
+        resolve(input.value || current);
+      };
 
       overlay.addEventListener('click', (evt) => {
         if (evt.target === overlay) {
@@ -349,9 +353,14 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       });
 
-      overlay.appendChild(picker);
+      const container = document.createElement('div');
+      container.className = 'emoji-picker';
+      container.appendChild(input);
+      container.appendChild(button);
+
+      overlay.appendChild(container);
       document.body.appendChild(overlay);
-      picker.focus();
+      input.focus();
     });
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,6 @@
     "type": "module"
   },
   "content_security_policy": {
-    "extension_pages": "script-src 'self' https://cdn.jsdelivr.net; object-src 'self'"
+    "extension_pages": "script-src 'self'; object-src 'self'"
   }
 }


### PR DESCRIPTION
## Summary
- remove CDN host from content security policy
- drop remote emoji picker from the HTML
- add a simple built‑in emoji picker and styling
- mention the new prompt-based picker in the README

## Testing
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_684811fa22608323b6d0a6c5467f651c