### PR TITLE
Bump manifest version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 "manifest_version": 3,
 "name": "Tab Manager Dashboard",
 "description": "Group tabs under categories and open them quickly via a New Tab dashboard",
-"version": "1.0",
+"version": "1.0.1",
   "permissions": ["tabs", "storage", "contextMenus", "scripting"],
 "chrome_url_overrides": {
 "newtab": "dashboard.html"


### PR DESCRIPTION
## Summary
- bump Chrome extension version in `manifest.json`

## Testing
- `npm run format`
- `npm test` *(fails: `Error: no test specified`)*

------
https://chatgpt.com/codex/tasks/task_e_684a9d54040083239aa62f18ef8e1752