### PR TITLE
Add keyboard shortcuts and command handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Tab Manager Dashboard is a minimal Chrome extension that lets you organize your 
 
 All saved data is kept in Chrome's synced storage, so categories follow you across devices as long as you are signed into Chrome.
 
+## Keyboard Shortcuts
+
+Two commands are available and can be configured under `chrome://extensions/shortcuts`:
+
+- **Save all tabs** (`Alt+Shift+S` by default)
+- **Open dashboard** (`Alt+Shift+D` by default)
+
+You may change the shortcuts on the extensions page to whatever works best for you.
+
 ## Development
 
 The core logic lives in `dashboard.js`, while `dashboard.html` defines the layout and `dashboard.css` contains styles. `manifest.json` configures the extension as a Chrome extension using Manifest V3.

--- a/background.js
+++ b/background.js
@@ -23,3 +23,25 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
     );
   }
 });
+
+chrome.commands.onCommand.addListener((command) => {
+  if (command === 'save-tabs') {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      const tab = tabs[0];
+      if (!tab) return;
+      chrome.scripting.executeScript(
+        {
+          target: { tabId: tab.id },
+          func: () => prompt('Enter category name:'),
+        },
+        (results) => {
+          if (chrome.runtime.lastError) return;
+          const cat = results && results[0] ? results[0].result : null;
+          if (cat) saveTabs(cat);
+        },
+      );
+    });
+  } else if (command === 'open-dashboard') {
+    chrome.tabs.create({ url: chrome.runtime.getURL('dashboard.html') });
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,16 @@
     "service_worker": "background.js",
     "type": "module"
   },
+  "commands": {
+    "save-tabs": {
+      "suggested_key": { "default": "Alt+Shift+S" },
+      "description": "Save all open tabs"
+    },
+    "open-dashboard": {
+      "suggested_key": { "default": "Alt+Shift+D" },
+      "description": "Open the dashboard"
+    }
+  },
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"
   }


### PR DESCRIPTION
## Summary
- declare `commands` in the Chrome extension manifest
- react to `chrome.commands.onCommand` in `background.js`
- document default shortcuts in `README`

## Testing
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_684ae9ee4e50832382976625baaebdab