### PR TITLE
Add URL editing field when renaming tabs

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -260,6 +260,44 @@ main#dashboard {
   z-index: 1000;
 }
 
+.edit-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.edit-dialog {
+  background: var(--card-bg);
+  padding: 20px;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.edit-dialog input {
+  padding: 5px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+}
+
+.edit-dialog button {
+  align-self: flex-end;
+  padding: 5px 10px;
+  border: none;
+  border-radius: 4px;
+  background: var(--primary);
+  color: #fff;
+  cursor: pointer;
+}
+
 .tab-list li a {
   text-decoration: none;
   color: var(--text);


### PR DESCRIPTION
## Summary
- allow editing a tab's url from the rename popup
- add modal for editing title and url
- style new edit popup

## Testing
- `npm run format`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68516b861e748323b19f43afe609078a