### PR TITLE
Hide dashboard from open tabs list

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -144,8 +144,10 @@ document.addEventListener('DOMContentLoaded', () => {
   // Load currently open tabs
   function loadOpenTabs() {
     chrome.tabs.query({ currentWindow: true }, (tabs) => {
+      const dashboardUrl = chrome.runtime.getURL('dashboard.html');
       openTabsList.innerHTML = '';
       tabs.forEach((tab) => {
+        if (tab.url && tab.url.startsWith(dashboardUrl)) return;
         const li = document.createElement('li');
         const img = document.createElement('img');
         img.src = tab.favIconUrl || `chrome://favicon/${tab.url}`;


### PR DESCRIPTION
## Summary
- exclude the dashboard page from the open tabs listing

## Testing
- `npm run format`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68517310329883239da394a103fec686