### PR TITLE
Fix Add URL input for autofill

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -365,6 +365,7 @@ document.addEventListener('DOMContentLoaded', () => {
         manual.className = 'manual-add';
         const inp = document.createElement('input');
         inp.type = 'text';
+        inp.name = 'url';
         inp.placeholder = 'Add URL';
         const btn = document.createElement('button');
         btn.textContent = 'Add';


### PR DESCRIPTION
## Summary
- add a `name` attribute to the dynamic "Add URL" input field so browsers can autofill it

## Testing
- `npm run format`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686f9bf642b08323b5ccdd5700d1539b