### PR TITLE
Fix sync fallback when quota exceeded

### DIFF
--- a/test/utils.test.mjs
+++ b/test/utils.test.mjs
@@ -134,9 +134,14 @@ test('storageSet falls back to local on error', async () => {
   const chrome = mockChrome();
   let syncCalled = false;
   let localCalled = false;
+  let removeKeys = null;
   chrome.storage.sync.set = (data, cb) => {
     syncCalled = true;
     chrome.runtime.lastError = { message: 'fail' };
+    cb();
+  };
+  chrome.storage.sync.remove = (keys, cb) => {
+    removeKeys = keys;
     cb();
   };
   chrome.storage.local.set = (data, cb) => {
@@ -150,5 +155,6 @@ test('storageSet falls back to local on error', async () => {
   });
   assert.ok(syncCalled);
   assert.ok(localCalled);
+  assert.deepEqual(removeKeys, ['a']);
   restoreChrome(original);
 });

--- a/utils.js
+++ b/utils.js
@@ -18,7 +18,9 @@ export function storageGet(defaults, callback) {
 export function storageSet(data, callback) {
   chrome.storage.sync.set(data, () => {
     if (chrome.runtime.lastError) {
-      chrome.storage.local.set(data, callback);
+      chrome.storage.sync.remove(Object.keys(data), () => {
+        chrome.storage.local.set(data, callback);
+      });
     } else if (callback) callback();
   });
 }


### PR DESCRIPTION
## Summary
- clean up sync storage when writing fails due to quota
- test removal of stale sync keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fba1d54d08323a28bd79dfd0d58e3